### PR TITLE
fix(testing): transform okta-angular for jest tests

### DIFF
--- a/apps/angular-jest/jest.config.ts
+++ b/apps/angular-jest/jest.config.ts
@@ -13,7 +13,7 @@ export default {
   transform: {
     '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!(@okta/okta-angular)|(.*\\.mjs$|))'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/apps/angular-jest/src/app/app.component.ts
+++ b/apps/angular-jest/src/app/app.component.ts
@@ -1,11 +1,13 @@
 import { Component, inject } from '@angular/core';
-import { OKTA_AUTH } from '@okta/okta-angular';
+import { OktaAuthModule, OKTA_AUTH } from '@okta/okta-angular';
+import { oktaConfig } from './app.config';
 
 @Component({
   selector: 'angular-jest-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
   standalone: true,
+  providers: [{ provide: OKTA_AUTH, useValue: oktaConfig }],
 })
 export class AppComponent {
   private _oktaAuth = inject(OKTA_AUTH);


### PR DESCRIPTION
Jest only understand common js and okta-angular only ships ESM so it has to be transformed for jest to work.